### PR TITLE
Clean up scheduler filter code

### DIFF
--- a/lfg-scheduler.js
+++ b/lfg-scheduler.js
@@ -240,17 +240,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Show/hide system-other input
-    document.getElementById('system').addEventListener('change', function() {
-        const otherInput = document.getElementById('system-other');
-        if (this.value === 'Other') {
-            otherInput.style.display = '';
-        } else {
-            otherInput.style.display = 'none';
-            otherInput.value = '';
-        }
-    });
-
     // Filtering (only by play preference)
     const playPrefSelect = document.getElementById('filter-playpref');
     if (playPrefSelect) {


### PR DESCRIPTION
## Summary
- remove leftover system filter UI logic
- ensure profile refresh relies only on the play preference filter

## Testing
- `python3 -m py_compile parse_tasks.py`

------
https://chatgpt.com/codex/tasks/task_e_68420aedf09c8333879e5c7f4419c36c