### PR TITLE
Add mobile D&D character sheet hub

### DIFF
--- a/dnd-character.css
+++ b/dnd-character.css
@@ -1,0 +1,316 @@
+:root {
+  color-scheme: light;
+  --bg: #f8fafc;
+  --text: #0f172a;
+  --muted: #475569;
+  --card: #ffffff;
+  --accent: #2563eb;
+  --border: #e2e8f0;
+  --shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
+  --radius: 18px;
+  --sheet-scale: 1;
+  --font-scale: 1;
+}
+
+body.dark {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --card: #111827;
+  --accent: #38bdf8;
+  --border: #1f2937;
+  --shadow: 0 10px 30px rgba(8, 12, 26, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+  font-size: calc(16px * var(--font-scale));
+}
+
+main {
+  padding: 0 1.25rem 3rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-header {
+  padding: 2rem 1.5rem 1.5rem;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.1), rgba(14, 116, 144, 0.2));
+  border-bottom: 1px solid var(--border);
+}
+
+.header-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin: 0 0 0.5rem;
+  color: var(--muted);
+}
+
+h1 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.subhead {
+  margin: 0.5rem 0 0;
+  color: var(--muted);
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button.primary {
+  background: var(--accent);
+  color: #fff;
+  box-shadow: var(--shadow);
+}
+
+.button.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.button:active {
+  transform: scale(0.98);
+}
+
+.quick-nav {
+  display: flex;
+  gap: 1rem;
+  padding-top: 1.25rem;
+  flex-wrap: wrap;
+}
+
+.quick-nav a {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.9rem;
+}
+
+.section {
+  margin-top: 2.5rem;
+}
+
+.section-header h2 {
+  margin-bottom: 0.2rem;
+}
+
+.section-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.sheet-wrapper {
+  margin-top: 1.5rem;
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1rem;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.sheet-toolbar {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.sheet-embed {
+  position: relative;
+  padding-top: 130%;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  transform: scale(var(--sheet-scale));
+  transform-origin: top left;
+}
+
+.sheet-embed iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background: #fff;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+}
+
+.card h3 {
+  margin-top: 0;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.dice-controls {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.dice-controls label,
+.hp-grid label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+input,
+select,
+textarea {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  padding: 0.55rem 0.75rem;
+  background: transparent;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+textarea {
+  width: 100%;
+  min-height: 160px;
+  resize: vertical;
+  margin-top: 1rem;
+}
+
+.dice-output {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.dice-history {
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.hp-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.hp-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.slots {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.slot-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.slot-controls {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.conditions {
+  display: grid;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.condition-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+
+.notes-actions {
+  margin-top: 1rem;
+}
+
+.site-footer {
+  padding: 1.5rem;
+  text-align: center;
+  color: var(--muted);
+  border-top: 1px solid var(--border);
+}
+
+@media (min-width: 900px) {
+  main {
+    padding: 0 4rem 4rem;
+  }
+
+  .header-content {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sheet-embed {
+    padding-top: 85%;
+  }
+}

--- a/dnd-character.html
+++ b/dnd-character.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0f172a">
+  <title>Sean's D&D Character Sheet</title>
+  <link rel="stylesheet" href="dnd-character.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="header-content">
+      <div>
+        <p class="eyebrow">Session-ready character hub</p>
+        <h1>Sean's D&amp;D Character Sheet</h1>
+        <p class="subhead">Mobile-first access to your D&amp;D Beyond sheet plus fast tools for table play.</p>
+      </div>
+      <div class="header-actions">
+        <a class="button primary" href="https://www.dndbeyond.com/sheet-pdfs/technhiesean_152284979.pdf" target="_blank" rel="noopener">Open PDF</a>
+        <button class="button ghost" id="toggle-theme" type="button">Toggle Dark Mode</button>
+      </div>
+    </div>
+    <nav class="quick-nav">
+      <a href="#sheet">Sheet</a>
+      <a href="#tools">Toolkit</a>
+      <a href="#notes">Notes</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="sheet" class="section">
+      <div class="section-header">
+        <h2>Character Sheet</h2>
+        <p>Pinch to zoom. Tap the full-screen button for a distraction-free view.</p>
+      </div>
+      <div class="sheet-wrapper">
+        <div class="sheet-toolbar">
+          <button class="button ghost" id="zoom-out" type="button" aria-label="Zoom out">A-</button>
+          <button class="button ghost" id="zoom-in" type="button" aria-label="Zoom in">A+</button>
+          <button class="button ghost" id="sheet-fullscreen" type="button">Full Screen</button>
+        </div>
+        <div class="sheet-embed" id="sheet-embed">
+          <iframe
+            title="Sean's Character Sheet"
+            src="https://www.dndbeyond.com/sheet-pdfs/technhiesean_152284979.pdf#view=fitH"
+          ></iframe>
+        </div>
+      </div>
+    </section>
+
+    <section id="tools" class="section">
+      <div class="section-header">
+        <h2>Session Toolkit</h2>
+        <p>Keep essentials at your fingertips: roll dice, track HP, and monitor conditions.</p>
+      </div>
+
+      <div class="grid">
+        <article class="card" aria-live="polite">
+          <h3>Dice Roller</h3>
+          <div class="dice-controls">
+            <label>
+              Dice
+              <select id="dice-type">
+                <option value="4">d4</option>
+                <option value="6">d6</option>
+                <option value="8">d8</option>
+                <option value="10">d10</option>
+                <option value="12">d12</option>
+                <option value="20" selected>d20</option>
+                <option value="100">d100</option>
+              </select>
+            </label>
+            <label>
+              Count
+              <input id="dice-count" type="number" min="1" max="10" value="1">
+            </label>
+            <label>
+              Mode
+              <select id="dice-mode">
+                <option value="normal" selected>Normal</option>
+                <option value="adv">Advantage</option>
+                <option value="dis">Disadvantage</option>
+              </select>
+            </label>
+          </div>
+          <button class="button primary" id="roll-dice" type="button">Roll</button>
+          <div class="dice-output" id="dice-output">Ready to roll.</div>
+          <div class="dice-history" id="dice-history"></div>
+        </article>
+
+        <article class="card">
+          <h3>HP Tracker</h3>
+          <div class="hp-grid">
+            <label>
+              Max HP
+              <input id="hp-max" type="number" min="1" value="1">
+            </label>
+            <label>
+              Current HP
+              <input id="hp-current" type="number" min="0" value="1">
+            </label>
+            <label>
+              Temp HP
+              <input id="hp-temp" type="number" min="0" value="0">
+            </label>
+          </div>
+          <div class="hp-actions">
+            <button class="button ghost" data-hp-change="-5" type="button">-5</button>
+            <button class="button ghost" data-hp-change="-1" type="button">-1</button>
+            <button class="button ghost" data-hp-change="1" type="button">+1</button>
+            <button class="button ghost" data-hp-change="5" type="button">+5</button>
+          </div>
+          <div class="hp-actions">
+            <button class="button ghost" id="hp-reset" type="button">Reset to Max</button>
+            <button class="button ghost" id="hp-clear-temp" type="button">Clear Temp</button>
+          </div>
+        </article>
+
+        <article class="card">
+          <h3>Spell Slots</h3>
+          <p class="muted">Tap plus/minus to spend or restore slots. Edit totals if you level up.</p>
+          <div class="slots" id="slot-list"></div>
+        </article>
+
+        <article class="card">
+          <h3>Conditions</h3>
+          <div class="conditions" id="condition-list"></div>
+        </article>
+      </div>
+    </section>
+
+    <section id="notes" class="section">
+      <div class="section-header">
+        <h2>Session Notes</h2>
+        <p>Auto-saved locally for quick recall between sessions.</p>
+      </div>
+      <textarea id="session-notes" placeholder="NPC names, loot, goals, reminders..."></textarea>
+      <div class="notes-actions">
+        <button class="button ghost" id="notes-clear" type="button">Clear Notes</button>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>Made for quick mobile access. Data is stored locally on your device.</p>
+  </footer>
+
+  <script src="dnd-character.js"></script>
+</body>
+</html>

--- a/dnd-character.js
+++ b/dnd-character.js
@@ -1,0 +1,290 @@
+const storage = {
+  get(key, fallback) {
+    try {
+      const raw = localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : fallback;
+    } catch (error) {
+      return fallback;
+    }
+  },
+  set(key, value) {
+    localStorage.setItem(key, JSON.stringify(value));
+  },
+};
+
+const body = document.body;
+const themeToggle = document.getElementById("toggle-theme");
+const sheetEmbed = document.getElementById("sheet-embed");
+const zoomIn = document.getElementById("zoom-in");
+const zoomOut = document.getElementById("zoom-out");
+const fullscreenButton = document.getElementById("sheet-fullscreen");
+
+const diceType = document.getElementById("dice-type");
+const diceCount = document.getElementById("dice-count");
+const diceMode = document.getElementById("dice-mode");
+const rollDice = document.getElementById("roll-dice");
+const diceOutput = document.getElementById("dice-output");
+const diceHistory = document.getElementById("dice-history");
+
+const hpMax = document.getElementById("hp-max");
+const hpCurrent = document.getElementById("hp-current");
+const hpTemp = document.getElementById("hp-temp");
+const hpReset = document.getElementById("hp-reset");
+const hpClearTemp = document.getElementById("hp-clear-temp");
+
+const slotList = document.getElementById("slot-list");
+const conditionList = document.getElementById("condition-list");
+const notesField = document.getElementById("session-notes");
+const notesClear = document.getElementById("notes-clear");
+
+const state = {
+  theme: storage.get("dnd-theme", "light"),
+  sheetScale: storage.get("dnd-sheet-scale", 1),
+  diceHistory: storage.get("dnd-dice-history", []),
+  hp: storage.get("dnd-hp", { max: 1, current: 1, temp: 0 }),
+  slots: storage.get(
+    "dnd-slots",
+    Array.from({ length: 9 }, (_, i) => ({ level: i + 1, total: 0, used: 0 }))
+  ),
+  conditions: storage.get("dnd-conditions", {}),
+  notes: storage.get("dnd-notes", ""),
+};
+
+const conditionNames = [
+  "Blinded",
+  "Charmed",
+  "Deafened",
+  "Frightened",
+  "Grappled",
+  "Incapacitated",
+  "Invisible",
+  "Paralyzed",
+  "Petrified",
+  "Poisoned",
+  "Prone",
+  "Restrained",
+  "Stunned",
+  "Unconscious",
+  "Exhaustion",
+];
+
+function applyTheme() {
+  body.classList.toggle("dark", state.theme === "dark");
+  themeToggle.textContent = state.theme === "dark" ? "Light Mode" : "Dark Mode";
+}
+
+function applySheetScale() {
+  const scale = Math.max(0.8, Math.min(1.4, state.sheetScale));
+  sheetEmbed.style.setProperty("--sheet-scale", scale);
+  state.sheetScale = scale;
+  storage.set("dnd-sheet-scale", scale);
+}
+
+function pushDiceHistory(entry) {
+  state.diceHistory.unshift(entry);
+  state.diceHistory = state.diceHistory.slice(0, 5);
+  storage.set("dnd-dice-history", state.diceHistory);
+  renderDiceHistory();
+}
+
+function renderDiceHistory() {
+  diceHistory.textContent = state.diceHistory.length
+    ? `Last rolls: ${state.diceHistory.join(" • ")}`
+    : "";
+}
+
+function roll({ sides, count, mode }) {
+  const rolls = Array.from({ length: count }, () => 1 + Math.floor(Math.random() * sides));
+  if (sides === 20 && mode !== "normal" && count === 1) {
+    const alt = 1 + Math.floor(Math.random() * sides);
+    rolls.push(alt);
+    const result = mode === "adv" ? Math.max(...rolls) : Math.min(...rolls);
+    return { rolls, total: result, mode };
+  }
+  const total = rolls.reduce((sum, value) => sum + value, 0);
+  return { rolls, total, mode: "normal" };
+}
+
+function handleRoll() {
+  const sides = Number(diceType.value);
+  const count = Math.max(1, Number(diceCount.value));
+  const mode = diceMode.value;
+  const result = roll({ sides, count, mode });
+  const rollText = result.rolls.join(", ");
+  diceOutput.textContent = `Rolled ${count}d${sides}${result.mode !== "normal" ? ` (${result.mode})` : ""}: ${rollText} → Total ${result.total}`;
+  pushDiceHistory(`${count}d${sides} = ${result.total}`);
+}
+
+function updateHpFromInputs() {
+  const max = Math.max(1, Number(hpMax.value));
+  const current = Math.max(0, Math.min(max, Number(hpCurrent.value)));
+  const temp = Math.max(0, Number(hpTemp.value));
+  hpMax.value = max;
+  hpCurrent.value = current;
+  hpTemp.value = temp;
+  state.hp = { max, current, temp };
+  storage.set("dnd-hp", state.hp);
+}
+
+function applyHpChange(delta) {
+  hpCurrent.value = Math.max(0, Number(hpCurrent.value) + delta);
+  updateHpFromInputs();
+}
+
+function renderSlots() {
+  slotList.innerHTML = "";
+  state.slots.forEach((slot, index) => {
+    const row = document.createElement("div");
+    row.className = "slot-row";
+
+    const label = document.createElement("div");
+    label.textContent = `Level ${slot.level}`;
+
+    const totals = document.createElement("input");
+    totals.type = "number";
+    totals.min = "0";
+    totals.value = slot.total;
+    totals.addEventListener("change", () => {
+      const value = Math.max(0, Number(totals.value));
+      state.slots[index].total = value;
+      if (state.slots[index].used > value) {
+        state.slots[index].used = value;
+      }
+      storage.set("dnd-slots", state.slots);
+      renderSlots();
+    });
+
+    const controls = document.createElement("div");
+    controls.className = "slot-controls";
+
+    const minus = document.createElement("button");
+    minus.className = "button ghost";
+    minus.type = "button";
+    minus.textContent = "-";
+    minus.addEventListener("click", () => {
+      state.slots[index].used = Math.max(0, slot.used - 1);
+      storage.set("dnd-slots", state.slots);
+      renderSlots();
+    });
+
+    const used = document.createElement("span");
+    used.textContent = `${slot.used}/${slot.total}`;
+
+    const plus = document.createElement("button");
+    plus.className = "button ghost";
+    plus.type = "button";
+    plus.textContent = "+";
+    plus.addEventListener("click", () => {
+      state.slots[index].used = Math.min(slot.total, slot.used + 1);
+      storage.set("dnd-slots", state.slots);
+      renderSlots();
+    });
+
+    controls.append(minus, used, plus);
+    row.append(label, totals, controls);
+    slotList.append(row);
+  });
+}
+
+function renderConditions() {
+  conditionList.innerHTML = "";
+  conditionNames.forEach((name) => {
+    const item = document.createElement("label");
+    item.className = "condition-item";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = Boolean(state.conditions[name]);
+    checkbox.addEventListener("change", () => {
+      state.conditions[name] = checkbox.checked;
+      storage.set("dnd-conditions", state.conditions);
+    });
+
+    const text = document.createElement("span");
+    text.textContent = name;
+
+    item.append(checkbox, text);
+    conditionList.append(item);
+  });
+}
+
+function initNotes() {
+  notesField.value = state.notes;
+  notesField.addEventListener("input", () => {
+    state.notes = notesField.value;
+    storage.set("dnd-notes", state.notes);
+  });
+  notesClear.addEventListener("click", () => {
+    notesField.value = "";
+    state.notes = "";
+    storage.set("dnd-notes", "");
+  });
+}
+
+function initHp() {
+  hpMax.value = state.hp.max;
+  hpCurrent.value = state.hp.current;
+  hpTemp.value = state.hp.temp;
+  hpMax.addEventListener("change", updateHpFromInputs);
+  hpCurrent.addEventListener("change", updateHpFromInputs);
+  hpTemp.addEventListener("change", updateHpFromInputs);
+
+  document.querySelectorAll("[data-hp-change]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const delta = Number(button.dataset.hpChange);
+      applyHpChange(delta);
+    });
+  });
+
+  hpReset.addEventListener("click", () => {
+    hpCurrent.value = hpMax.value;
+    updateHpFromInputs();
+  });
+
+  hpClearTemp.addEventListener("click", () => {
+    hpTemp.value = 0;
+    updateHpFromInputs();
+  });
+}
+
+function initTheme() {
+  applyTheme();
+  themeToggle.addEventListener("click", () => {
+    state.theme = state.theme === "dark" ? "light" : "dark";
+    storage.set("dnd-theme", state.theme);
+    applyTheme();
+  });
+}
+
+function initSheetControls() {
+  applySheetScale();
+  zoomIn.addEventListener("click", () => {
+    state.sheetScale += 0.1;
+    applySheetScale();
+  });
+  zoomOut.addEventListener("click", () => {
+    state.sheetScale -= 0.1;
+    applySheetScale();
+  });
+  fullscreenButton.addEventListener("click", () => {
+    const target = document.getElementById("sheet-embed");
+    if (document.fullscreenElement) {
+      document.exitFullscreen();
+    } else {
+      target.requestFullscreen().catch(() => {});
+    }
+  });
+}
+
+function init() {
+  initTheme();
+  initSheetControls();
+  renderDiceHistory();
+  rollDice.addEventListener("click", handleRoll);
+  initHp();
+  renderSlots();
+  renderConditions();
+  initNotes();
+}
+
+init();

--- a/index.md
+++ b/index.md
@@ -47,6 +47,12 @@ A multi-part case study analyzing ride patterns, user types, and business recomm
 
 👉 [Try the Group Finder App](lfg-finder.html)
 
+### 📜 Character Sheet Companion
+
+Access Sean's mobile-friendly character sheet hub with a built-in dice roller, HP tracker, and session notes.
+
+👉 [Open the Character Sheet Hub](dnd-character.html)
+
 ---
 
 ## 📚 Resources & Reports


### PR DESCRIPTION
### Motivation

- Provide a mobile-first way to view the D&D Beyond PDF character sheet and improve in-session usability on a phone with a compact, fast UI.
- Surface common session tools (dice, HP, spell slots, conditions, and quick notes) so the player can avoid switching apps during play.

### Description

- Add `dnd-character.html` which embeds the D&D Beyond PDF (`https://www.dndbeyond.com/sheet-pdfs/technhiesean_152284979.pdf`) and provides sections for the sheet, toolkit, and session notes.
- Add `dnd-character.css` with responsive, theme-aware styling and mobile-first layout for cards, toolbar, and embedded PDF scaling.
- Add `dnd-character.js` implementing localStorage-backed helpers for the dice roller (including advantage/disadvantage), HP tracker (quick delta buttons, reset, temp HP), editable spell slots (spend/restore), condition toggles, theme toggle, sheet zoom controls, fullscreen and session notes autosave.
- Link the new hub from `index.md` under a new "Character Sheet Companion" entry.

### Testing

- Performed a local smoke test by serving the site with `python -m http.server 8000` and loading `http://127.0.0.1:8000/dnd-character.html` with a headless Chromium Playwright script at mobile viewport, and a screenshot `artifacts/dnd-character-mobile.png` was produced successfully.
- No unit tests were added; changes are static frontend assets and passed the described automated smoke check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abc5c702c8333932c652338b72c37)